### PR TITLE
Next draft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# © 2025 Marc Nieper-Wißkirchen.
+
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice (including
+# the next paragraph) shall be included in all copies or substantial
+# portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# SPDX-FileCopyrightText: 2024 Marc Nieper-Wißkirchen
+# SPDX-License-Identifier: MIT
+
+scheme = scheme --libdirs lib --program
+
+check:
+	$(scheme) tests.sps
+
+.PHONY:	check

--- a/lib/srfi/:254.sls
+++ b/lib/srfi/:254.sls
@@ -1,5 +1,28 @@
 #!chezscheme
 
+;; © 2024 Marc Nieper-Wißkirchen.
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice (including
+;; the next paragraph) shall be included in all copies or substantial
+;; portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
 ;; SPDX-FileCopyrightText: 2024 Marc Nieper-Wißkirchen
 ;; SPDX-License-Identifier: MIT
 
@@ -11,6 +34,7 @@
     ephemeron-key
     ephemeron-value
     ephemeron-broken?
+    ephemeron-ref
     make-guardian
     guardian?
     current-hash
@@ -61,6 +85,17 @@
       (assert (ephemeron-pair? eph))
       (let ([value (cdr eph)])
         (and (not (bwp-object? (car eph))) value))))
+
+  (define ephemeron-ref
+    (case-lambda
+      [(eph key default)
+       (assert (ephemeron-pair? eph))
+       (if (eq? (ephemeron-key eph) key)
+           (let ([val (ephemeron-value eph)])
+             (reference-barrier key)
+             val)
+           default)]
+      [(eph key) (ephemeron-ref eph key #f)]))
 
   ;; Guardians
 

--- a/lib/srfi/:254/ephemerons-and-guardians.sls
+++ b/lib/srfi/:254/ephemerons-and-guardians.sls
@@ -11,6 +11,7 @@
     ephemeron-key
     ephemeron-value
     ephemeron-broken?
+    ephemeron-ref
     make-guardian
     guardian?
     current-hash

--- a/lib/srfi/:254/ephemerons-and-guardians/ephemerons.sls
+++ b/lib/srfi/:254/ephemerons-and-guardians/ephemerons.sls
@@ -10,5 +10,6 @@
     ephemeron?
     ephemeron-key
     ephemeron-value
-    ephemeron-broken?)
+    ephemeron-broken?
+    ephemeron-ref)
   (import (srfi :254)))

--- a/srfi-254.html
+++ b/srfi-254.html
@@ -486,38 +486,38 @@
     (lambda (wm key)
       (assert (weakmap? wm))
       (let f ([entries (weakmap-entries wm)])
-        (cond ((null? entries)
+        (cond [(null? entries)
                (reference-barrier key)
-              #f)
-              ((eq? (ephemeron-key (car entries)) key)
+               #f]
+              [(eq? (ephemeron-key (car entries)) key)
                (reference-barrier key)
-               #t)
-              (else (f (cdr entries)))))))
+               #t]
+              [else (f (cdr entries))])))))
 
   (define weakmap-set!
     (lambda (wm key val)
       (assert (weakmap? wm))
       (let f ([entries (weakmap-entries wm)]
               [set-tail! (lambda (tail) (weakmap-entries-set! wm tail))])
-        (cond ((null? entries)
-               (set-tail! (list (make-ephemeron key val))))
-              ((eq? (ephemeron-key (car entries)) key)
-               (set-tail! (cons (make-ephemeron key val) (cdr entries))))
-              (else (f (cdr entries)
-                       (lambda (tail) (set-cdr! entries tail))))))))
+        (cond [(null? entries)
+               (set-tail! (list (make-ephemeron key val)))]
+              [(eq? (ephemeron-key (car entries)) key)
+               (set-tail! (cons (make-ephemeron key val) (cdr entries)))]
+              [else (f (cdr entries)
+                       (lambda (tail) (set-cdr! entries tail)))]))))
 
   (define weakmap-ref
     (lambda (wm key default)
       (assert (weakmap? wm))
       (let f ([entries (weakmap-entries wm)])
-        (cond ((null? entries)
+        (cond [(null? entries)
                (reference-barrier key)
-               default)
-              ((eq? (ephemeron-key (car entries)) key)
+               default]
+              [(eq? (ephemeron-key (car entries)) key)
                (let ([val (ephemeron-value (car entries))])
                   (reference-barrier key)
-                  val))
-              (else (f (cdr entries)))))))
+                  val)]
+              [else (f (cdr entries))]))))
 
   (define weakmap-delete!
     (lambda (wm key)
@@ -581,12 +581,12 @@
   (lambda (wm key default)
     (assert (weakmap? wm))
     (let f ([entries (weakmap-entries wm)])
-      (cond ((null? entries)
+      (cond [(null? entries)
              (reference-barrier key)
-             default)
-            (else
+             default]
+            [else
              (or (ephemeron-ref (car entries) key)
-                 (f (cdr entries))))))))
+                 (f (cdr entries)))]))))
 </pre>
 
     <h2 id="implementation">Implementation</h2>

--- a/srfi-254.html
+++ b/srfi-254.html
@@ -574,6 +574,21 @@
             (weakmap-ref wm tmp #f))))
 </pre>
 
+    <p>Here is a version of <code>weakmap-ref</code> that uses the convenience procedure <code>ephemeron-ref</code>:</p>
+
+<pre>
+(define weakmap-ref
+  (lambda (wm key default)
+    (assert (weakmap? wm))
+    (let f ([entries (weakmap-entries wm)])
+      (cond ((null? entries)
+             (reference-barrier key)
+             default)
+            (else
+             (or (ephemeron-ref (car entries) key)
+                 (f (cdr entries))))))))
+</pre>
+
     <h2 id="implementation">Implementation</h2>
 
     <p>An implementation for Chez Scheme is provided.</p>

--- a/srfi-254.html
+++ b/srfi-254.html
@@ -198,12 +198,12 @@
       If the content of an ephemeron's key field denotes a location or
       a sequence of locations, the ephemeron is broken in the course
       of the computation if the garbage collector would reclaim the
-      location or sequence of locations if the location denoted by the
-      ephemeron's value field were weakly holding.  The ephemeron may
-      be broken in the course of a computation if the Scheme
-      implementation can prove that the location or sequence of
-      locations will not be kept alive in the future of the computation
-      if the ephemeron is broken.
+      location or sequence of locations if the locations denoted by
+      the value fields of all (this and any other) ephemerons were
+      weakly holding.  The ephemeron may be broken in the course of a
+      computation if the Scheme implementation can prove that the
+      location or sequence of locations will not be kept alive in the
+      future of the computation if the ephemeron is broken.
     </p>
 
     <p>Procedure: <strong>reference-barrier</strong> <var>obj</var></p>
@@ -244,12 +244,33 @@
       of the value field of <var>ephemeron</var>.
     </p>
 
+    <p>The following two procedures are convenience procedures.  The
+      first procedure is not strictly necessary as <code>#f</code> is
+      not a portable key, denoting no location.  The second procedure
+      makes most uses of <code>reference-barrier</code> unnessary.</p>
+
     <p>Procedure: <strong>ephemeron-broken?</strong> <var>ephemeron</var></p>
 
     <p>The <code>ephemeron-broken?</code> procedure
       returns <code>#t</code> if <var>ephemeron</var> has been broken,
       and <code>#f</code> otherwise.
     </p>
+
+    <p>Procedure: <strong>ephemeron-ref</strong> <var>ephemeron</var> <var>key</var> [<var>default</var>]</p>
+
+    <p>If not given, the optional <var>default</var> defaults
+    to <code>#f</code>. The object <var>key</var> should denote a
+    location or a sequence of locations.</p>
+
+    <p>The <code>ephemeron-ref</code> procedure returns the contents
+      of the value field of <var>ephemeron</var> if the ephemeron
+      hasn't been broken and the contents of its key field
+      and <var>key</var> are equivalent in the sense
+      of <code>eq?</code>, and <var>default</var> otherwise.
+    </p>
+
+    <p>Moreover, the location or sequence of locations denoted
+      by <var>key</var> are kept alive.
 
     <h3>Guardians</h3>
 

--- a/srfi-254.html
+++ b/srfi-254.html
@@ -217,6 +217,43 @@
     <p><i>Comment:</i> Other procedures may keep locations alive as
       well.</p>
 
+    <p><i>Comment:</i> At least one procedure is needed that
+      guaranteedly keeps locations alive.  The alternative would have
+      been to require that every reference of a variable would keep
+      the location denoted by it alive but that would have
+      tremendously adverse consequences for optimizing compilers.</p>
+
+    <p>The following program using Chez Scheme's native ephemerons for
+      simplicity shows how code without <code>reference-barrier</code> or an equivalent construct is unreliable:</p>
+<pre>
+(import (scheme))
+
+(define eph #f)
+
+(define (f v)
+  (set! eph (ephemeron-cons v #t)))
+
+(define (g)
+  (car eph))
+
+(define (g/collect)
+  (collect)                             ;simulate GC
+  (car eph))
+
+(define foo
+  (lambda (f g)
+    (let ((v (vector 1 2)))
+      (f v)
+      (let ((w (g)))
+        (boolean=? (vector? v) (vector? w))))))
+
+(assert (foo f g))
+(assert (foo f g/collect))              ;fails
+</pre>
+
+    <p>The underlying reason here is that Chez Scheme's optimizer
+    replaces <code>(vector? v)</code> with <code>#t</code>.</p>
+
     <p>Procedure: <strong>make-ephemeron</strong> <var>key</var> <var>value</var></p>
 
     <p>The <code>make-ephemeron</code> procedure returns a newly

--- a/srfi-254.html
+++ b/srfi-254.html
@@ -585,6 +585,15 @@
       the papers on guardians.
     </p>
 
+    <p>In particular, I would like to thank Daphne Preston-Kendal as a
+      member of the SRFI discussion group for asking very good
+      questions and challenging the API and semantics, which helped
+      getting everything right.</p>
+
+    <p>Finally, I would like to thank Arthur Gleckler, SRFI editor,
+      for his patience with the long periods of relative inactivity
+      around this SRFI.</p>
+
     <h2 id="copyright">Copyright</h2>
     <p>&copy; 2024 Marc Nieper-Wißkirchen.</p>
 

--- a/tests.sps
+++ b/tests.sps
@@ -1,0 +1,39 @@
+#!r6rs
+
+;; © 2024 Marc Nieper-Wißkirchen.
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice (including
+;; the next paragraph) shall be included in all copies or substantial
+;; portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;; SPDX-FileCopyrightText: 2024 Marc Nieper-Wißkirchen
+;; SPDX-License-Identifier: MIT
+
+(import
+  (rnrs)
+  (srfi :254))
+
+(define k1 (vector #f))
+
+(define e1 (make-ephemeron k1 'foo))
+
+(assert (eqv? (ephemeron-ref e1 k1) 'foo))
+(assert (eqv? (ephemeron-ref e1 (vector #f) 'bar) 'bar))
+(assert (not (ephemeron-ref e1 (vector #f))))


### PR DESCRIPTION
The important changes in this draft are:

- Keys only held by other ephemeron's values may now be garbage collected, which allows breaking cycles of more than one ephemeron.
- Addition of the procedure <code>ephemeron-ref</code>, which covers the typical use cases where <code>reference-barrier</code> would otherwise be necessary.